### PR TITLE
Added a timeout to wait-irq

### DIFF
--- a/kernel/floppy.fs
+++ b/kernel/floppy.fs
@@ -23,6 +23,7 @@
 
 require @structures.fs
 require @kernel/timer.fs
+\ require @user.fs
 
 \ Registers
 : MSR  $3F4 inputb ;
@@ -50,10 +51,10 @@ BPS SPT * 2 * constant BPC              \ bytes per cylinder
 true  constant device>memory
 false constant memory>device
 
-\ TODO: Implement a timeout here
+
 variable irq6-received
 : wait-irq ( -- )
-    begin irq6-received @ not while halt repeat ;
+    time 4000 + begin dup time <= if ." Drive Timeout " drop exit then irq6-received @ not while halt repeat drop ;
 
 : wait-ready
     128 0 ?do RQM if unloop exit endif 10 ms loop ;

--- a/kernel/timer.fs
+++ b/kernel/timer.fs
@@ -77,6 +77,8 @@ variable countdown
 
 : get-internal-run-time internal-run-time @ ;
 
+: time get-internal-run-time ;
+
 \ Wait for (rougly) N milliseconds.
 : ms ( n -- )
     set-countdown wait-for-countdown ;


### PR DESCRIPTION
I used ." instead of abort" because user.fs is not available at the load time of floppy.fs. Once I figure out how exceptions work I'll refactor it to allow automatic detection of the timeout so the controller can be reset. The timeout mechanism is a simple "get the current time, and compare it to start time + some value, if current is greater, bail"

I also added "time" as a shorthand for get-internal-run-time, although for the purpose of the timeout, it doesn't matter if it returns current time or uptime, as long as it's in ms (change the 4000 to reflect the unit if it is changed)